### PR TITLE
Fix: Display Correct Number of Test Cases Passed in Submission Table

### DIFF
--- a/apps/web/components/SubmissionTable.tsx
+++ b/apps/web/components/SubmissionTable.tsx
@@ -21,9 +21,11 @@ export interface ISubmission {
   code: string;
   fullCode: string;
   status: string;
+
   testcases: {
-    status: string;
+
     index: number;
+    status_id:number;
   }[];
 }
 
@@ -49,19 +51,19 @@ function getColor(status: string) {
 function getIcon(status: string) {
   switch (status) {
     case "AC":
-      return <CheckIcon className="h-4 w-4" />;
+      return <CheckIcon className="w-4 h-4" />;
     case "FAIL":
-      return <CircleX className="h-4 w-4" />;
+      return <CircleX className="w-4 h-4" />;
     case "REJECTED":
-      return <CircleX className="h-4 w-4" />;
+      return <CircleX className="w-4 h-4" />;
     case "TLE":
-      return <ClockIcon className="h-4 w-4" />;
+      return <ClockIcon className="w-4 h-4" />;
     case "COMPILATION_ERROR":
-      return <CircleX className="h-4 w-4" />;
+      return <CircleX className="w-4 h-4" />;
     case "PENDING":
-      return <ClockIcon className="h-4 w-4" />;
+      return <ClockIcon className="w-4 h-4" />;
     default:
-      return <ClockIcon className="h-4 w-4" />;
+      return <ClockIcon className="w-4 h-4" />;
   }
 }
 
@@ -92,7 +94,7 @@ export function SubmissionTable({
               <TableCell>
                 {
                   submission.testcases.filter(
-                    (testcase) => testcase.status === "AC",
+                    (testcase) => testcase.status_id === 3,
                   ).length
                 }
                 /{submission.testcases.length}


### PR DESCRIPTION
This PR fixes the issue where the number of test cases passed is always displayed as 0 in the problem submission table.

Issue:#74

### Before
![localhost-3000-problem-cly1pj4n40001ivozl8t7skfm](https://github.com/code100x/algorithmic-arena/assets/68776478/0a695d02-bce6-4048-8254-b42e00e23bed)
![localhost-3000-problem-cly1pj4n40001ivozl8t7ssdkfm](https://github.com/code100x/algorithmic-arena/assets/68776478/89a16a75-fee1-4fe0-aab4-f0dde24b8c05)

### After
![localhost-3000-problem-cly1pj4n40001ivozl8tsdf7skfm](https://github.com/code100x/algorithmic-arena/assets/68776478/05eea1c1-56bc-48b6-9448-c95b4b1afad0)
![localhost-3000-problem-cly1pj4asdfn40001ivozl8t7skfm](https://github.com/code100x/algorithmic-arena/assets/68776478/596de8b6-eef0-4f38-918d-e29e676e0160)

